### PR TITLE
Fix: Resolve SyntaxError in eslint.config.js for ESLint 9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.21",
   "description": "USSD implementation for React Native",
   "main": "index.js",
+  "type": "module",
   "files": [
     "README.md",
     "android",
@@ -12,7 +13,8 @@
     "react-native-ussd.podspec"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint:js": "eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds `"type": "module"` to `package.json` to allow ES module syntax (e.g., `import`) in `.js` files, specifically to resolve a `SyntaxError` in `eslint.config.js` when parsed by ESLint 9.27.0.

Also adds the `"lint:js": "eslint ."` script to `package.json` as indicated by the pipeline's execution logs.

Note: Verification in the available environment was hindered by an older ESLint version (6.4.0) which does not recognize `eslint.config.js`. This change targets the ESLint 9.27.0 environment reported in the issue.