### PR TITLE
feat: Add GitHub Actions workflow for CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run linter
+        run: npm run lint:js
+      - name: Run tests
+        run: npm test
+
+  publish-npm:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm install
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -265,3 +265,28 @@ npm test dial.test.js
 ```
 
 Ensure you have installed the project dependencies (`npm install`) before running the tests.
+
+## CI/CD Pipeline
+
+This project uses GitHub Actions to automate linting, testing, and publishing to npm.
+
+**Workflow:**
+
+*   **Trigger:** The workflow automatically runs on every push to the `master` branch.
+*   **Jobs:**
+    1.  `lint-test`:
+        *   Checks out the code.
+        *   Sets up Node.js.
+        *   Installs dependencies (`npm install`).
+        *   Runs the linter (`npm run lint:js`).
+        *   Runs tests (`npm test`).
+    2.  `publish-npm`:
+        *   Depends on the successful completion of the `lint-test` job.
+        *   Checks out the code.
+        *   Sets up Node.js and configures it for npm publishing.
+        *   Installs dependencies (`npm install`).
+        *   Publishes the package to npm (`npm publish`).
+
+**NPM Publishing:**
+
+For automatic publishing to npm to work, a secret named `NPM_TOKEN` must be configured in the GitHub repository settings. This token should be an npm access token with permission to publish the package.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates linting, testing, and publishing to npm.

The workflow (`.github/workflows/main.yml`) is triggered on pushes to the `master` branch and consists of two jobs:

1.  `lint-test`:
    *   Checks out the code.
    *   Sets up Node.js (v18).
    *   Installs dependencies (`npm install`).
    *   Runs the ESLint linter (`npm run lint:js`).
    *   Runs Jest tests (`npm test`).

2.  `publish-npm`:
    *   Depends on the successful completion of the `lint-test` job.
    *   Checks out the code.
    *   Sets up Node.js (v18) and configures it for npm publishing.
    *   Installs dependencies (`npm install`).
    *   Publishes the package to npm (`npm publish`) using an `NPM_TOKEN`
        secret stored in GitHub repository secrets.

The `README.md` has been updated to include a section describing this new CI/CD pipeline and the requirement for the `NPM_TOKEN` secret.