### PR TITLE
Fix: Resolve React version conflict for react-native 0.79.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
         "@react-native/babel-preset": "^0.79.2",
         "babel-jest": "^30.0.0-beta.3",
         "jest": "^29.7.0",
-        "react": "^16.9.0",
+        "react": "^19.0.0",
         "react-native": "^0.79.2",
         "react-test-renderer": "^19.1.0"
       },
       "peerDependencies": {
-        "react": "^16.8.1",
-        "react-native": ">=0.60.0-rc.0 <1.0.x"
+        "react": "^19.0.0",
+        "react-native": "^0.79.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7518,15 +7518,6 @@
         "node": ">=18.18"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -7795,23 +7786,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -7847,15 +7821,10 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-ussd",
   "title": "React Native Ussd",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "USSD implementation for React Native",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
+    "react": "^19.0.0",
+    "react-native": "^0.79.2"
   },
   "devDependencies": {
     "@babel/core": "^7.27.3",
@@ -43,7 +43,7 @@
     "@react-native/babel-preset": "^0.79.2",
     "babel-jest": "^30.0.0-beta.3",
     "jest": "^29.7.0",
-    "react": "^16.9.0",
+    "react": "^19.0.0",
     "react-native": "^0.79.2",
     "react-test-renderer": "^19.1.0"
   }


### PR DESCRIPTION
The project had a dependency conflict where `react-native@0.79.2` requires `react@^19.0.0`, but the project's `peerDependencies` and `devDependencies` were set to `react@^16.x.x`.

This commit updates the following:
- `peerDependencies`:
  - `react` changed from `^16.8.1` to `^19.0.0`
  - `react-native` changed from `>=0.60.0-rc.0 <1.0.x` to `^0.79.2`
- `devDependencies`:
  - `react` changed from `^16.9.0` to `^19.0.0`

`npm install` now completes successfully, and all tests (`npm test`) pass with these updated dependencies. This should resolve the pipeline failures related to `ERESOLVE` during the `npm install` step.