### PR TITLE
Fix: Remove unused nativeModule parameter in NativeEventEmitter mock

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -40,7 +40,7 @@ const mockRemoveListenersImplementation = jest.fn((countOrEventName) => {
 });
 
 
-const NativeEventEmitter = jest.fn().mockImplementation(function(nativeModule) {
+const NativeEventEmitter = jest.fn().mockImplementation(function() {
   this.addListener = mockAddListenerImplementation; // Use the implementation
   this.removeListeners = mockRemoveListenersImplementation; // Use the implementation
   return this;


### PR DESCRIPTION
The `nativeModule` parameter in the mock implementation of `NativeEventEmitter` in `__mocks__/react-native.js` was not being used, leading to an ESLint `no-unused-vars` error. This commit removes the unused parameter.

This change allows the `npm run lint:js` step in the GitHub Actions workflow to pass, enabling the subsequent test and publish steps to proceed.